### PR TITLE
Core Guess

### DIFF
--- a/src/scf/fock_operator/fock_operator.hpp
+++ b/src/scf/fock_operator/fock_operator.hpp
@@ -19,17 +19,31 @@
 
 namespace scf::fock_operator {
 
-template<typename DensityType>
+template<typename DensityType, typename ElectronType>
 DECLARE_MODULE(Restricted);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {
     using simde::type::decomposable_e_density;
     using simde::type::e_density;
-    mm.add_module<Restricted<e_density>>("AO Restricted Fock Op");
-    mm.add_module<Restricted<decomposable_e_density>>("Restricted Fock Op");
+    using simde::type::electron;
+    using simde::type::many_electrons;
+    using e_many = Restricted<e_density, many_electrons>;
+    using e_e    = Restricted<e_density, electron>;
+    using d_many = Restricted<decomposable_e_density, many_electrons>;
+    using d_e    = Restricted<decomposable_e_density, electron>;
+
+    mm.add_module<e_many>("AO Restricted Fock Op");
+    mm.add_module<d_many>("Restricted Fock Op");
+    mm.add_module<e_e>("AO Restricted One-Electron Fock Op");
+    mm.add_module<d_e>("Restricted One-Electron Fock Op");
 }
 
-extern template class Restricted<simde::type::e_density>;
-extern template class Restricted<simde::type::decomposable_e_density>;
+#define EXTERN_RESTRICTED(density)                                          \
+    extern template class Restricted<density, simde::type::many_electrons>; \
+    extern template class Restricted<density, simde::type::electron>
 
+EXTERN_RESTRICTED(simde::type::e_density);
+EXTERN_RESTRICTED(simde::type::decomposable_e_density);
+
+#undef EXTERN_RESTRICTED
 } // namespace scf::fock_operator

--- a/src/scf/guess/core.cpp
+++ b/src/scf/guess/core.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "guess.hpp"
 
 namespace scf::guess {

--- a/src/scf/guess/core.cpp
+++ b/src/scf/guess/core.cpp
@@ -1,0 +1,46 @@
+#include "guess.hpp"
+
+namespace scf::guess {
+
+using rscf_wf    = simde::type::rscf_wf;
+using density_t  = simde::type::decomposable_e_density;
+using pt         = simde::InitialGuess<rscf_wf>;
+using fock_op_pt = simde::FockOperator<density_t>;
+using update_pt  = simde::UpdateGuess<rscf_wf>;
+
+const auto desc = R"(
+Core Guess
+----------
+
+TODO: Write me!!!
+)";
+
+MODULE_CTOR(Core) {
+    description(desc);
+    satisfies_property_type<pt>();
+    add_submodule<fock_op_pt>("Build Fock operator");
+    add_submodule<update_pt>("Guess updater");
+}
+
+MODULE_RUN(Core) {
+    // const auto&& [H, aos] = pt::unwrap_inputs(inputs);
+
+    // // Step 1: Build Fock Operator with zero density
+    // density_t rho;
+    // auto& fock_op_mod = submods.at("Build Fock operator");
+    // const auto& F     = fock_op_mod.run_as<fock_op_pt>(rho);
+
+    // // Step 2: Update guess Call module to update guess
+    // simde::type::cmos cmos(zero_vector, aos, Tensor{});
+    // typename rscf_wf::orbital_index_set_type occupations(aos.size(), 0);
+    // // Fill in occupations
+
+    // rscf_wf zero_guess(occupations aos, cmos);
+    // auto& update_mod = submods.at("Guess updater");
+    // const auto& Psi0 = update_mod.run_as<update_pt>(F, zero_guess);
+
+    // auto rv = results();
+    // return pt::wrap_results(rv, Psi0);
+}
+
+} // namespace scf::guess

--- a/src/scf/guess/guess.hpp
+++ b/src/scf/guess/guess.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <simde/simde.hpp>
 

--- a/src/scf/guess/guess.hpp
+++ b/src/scf/guess/guess.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <simde/simde.hpp>
+
+namespace scf::guess {
+
+DECLARE_MODULE(Core);
+
+inline void load_modules(pluginplay::ModuleManager& mm) {
+    mm.add_module<Core>("Core");
+}
+
+inline void set_defaults(pluginplay::ModuleManager& mm) {
+    mm.change_submod("Core", "Build Fock operator",
+                     "Restricted One-Electron Fock Op");
+    mm.change_submod("Core", "Guess updater", "Diagonalization Fock update.");
+}
+
+} // namespace scf::guess

--- a/src/scf/guess/guess.hpp
+++ b/src/scf/guess/guess.hpp
@@ -6,13 +6,14 @@ namespace scf::guess {
 DECLARE_MODULE(Core);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {
-    mm.add_module<Core>("Core");
+    mm.add_module<Core>("Core guess");
 }
 
 inline void set_defaults(pluginplay::ModuleManager& mm) {
-    mm.change_submod("Core", "Build Fock operator",
+    mm.change_submod("Core guess", "Build Fock operator",
                      "Restricted One-Electron Fock Op");
-    mm.change_submod("Core", "Guess updater", "Diagonalization Fock update.");
+    mm.change_submod("Core guess", "Guess updater",
+                     "Diagonalization Fock update");
 }
 
 } // namespace scf::guess

--- a/src/scf/matrix_builder/ao_integrals_driver.cpp
+++ b/src/scf/matrix_builder/ao_integrals_driver.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "matrix_builder.hpp"
 
 namespace scf::matrix_builder {

--- a/src/scf/matrix_builder/ao_integrals_driver.cpp
+++ b/src/scf/matrix_builder/ao_integrals_driver.cpp
@@ -1,0 +1,99 @@
+#include "matrix_builder.hpp"
+
+namespace scf::matrix_builder {
+
+namespace {
+
+const auto desc = R"(
+AO Integrals Driver
+-------------------
+)";
+
+}
+
+using pluginplay::type::submodule_map;
+using simde::type::aos;
+using simde::type::tensor;
+
+using pt      = simde::aos_op_base_aos;
+using t_e_pt  = simde::aos_t_e_aos;
+using v_en_pt = simde::aos_v_en_aos;
+using j_e_pt  = simde::aos_j_e_aos;
+using k_e_pt  = simde::aos_k_e_aos;
+using f_e_pt  = simde::aos_f_e_aos;
+
+class AODispatcher : public chemist::qm_operator::OperatorVisitor {
+public:
+    using t_e_type  = simde::type::t_e_type;
+    using v_en_type = simde::type::v_en_type;
+    using j_e_type  = simde::type::j_e_type;
+    using k_e_type  = simde::type::k_e_type;
+    using f_e_type  = simde::type::fock;
+
+    using submods_type = pluginplay::type::submodule_map;
+
+    AODispatcher(const aos& bra, const aos& ket, submodule_map& submods,
+                 tensor& t) :
+      m_pbra_(&bra), m_pket_(&ket), m_psubmods_(&submods), m_ptensor_(&t) {}
+
+    void run(const t_e_type& t_e) {
+        chemist::braket::BraKet input(*m_pbra_, t_e, *m_pket_);
+        *m_ptensor_ = m_psubmods_->at("Kinetic").run_as<t_e_pt>(input);
+    }
+
+    void run(const v_en_type& v_en) {
+        chemist::braket::BraKet input(*m_pbra_, v_en, *m_pket_);
+        const auto key = "Electron-Nuclear attraction";
+        *m_ptensor_    = m_psubmods_->at(key).run_as<v_en_pt>(input);
+    }
+
+    void run(const j_e_type& j_e) {
+        chemist::braket::BraKet input(*m_pbra_, j_e, *m_pket_);
+        const auto key = "Coulomb matrix";
+        *m_ptensor_    = m_psubmods_->at(key).run_as<j_e_pt>(input);
+    }
+
+    void run(const k_e_type& k_e) {
+        chemist::braket::BraKet input(*m_pbra_, k_e, *m_pket_);
+        const auto key = "Exchange matrix";
+        *m_ptensor_    = m_psubmods_->at(key).run_as<k_e_pt>(input);
+    }
+
+    // void run(const f_e_type& f_e) {
+    //     chemist::braket::BraKet input(*m_pbra_, f_e, *m_pket_);
+    //     const auto key = "Fock matrix";
+    //     *m_ptensor_    = m_psubmods_->at(key).run_as<f_e_pt>(input);
+    // }
+
+private:
+    const aos* m_pbra_;
+    const aos* m_pket_;
+    submodule_map* m_psubmods_;
+    tensor* m_ptensor_;
+};
+
+MODULE_CTOR(AOIntegralsDriver) {
+    description(desc);
+    satisfies_property_type<pt>();
+    add_submodule<t_e_pt>("Kinetic");
+    add_submodule<v_en_pt>("Electron-Nuclear attraction");
+    add_submodule<j_e_pt>("Coulomb matrix");
+    add_submodule<k_e_pt>("Exchange matrix");
+    // add_submodule<f_e_pt>("Fock matrix");
+}
+
+MODULE_RUN(AOIntegralsDriver) {
+    const auto&& [braket] = pt::unwrap_inputs(inputs);
+    const auto& bra       = braket.bra();
+    const auto& op        = braket.op();
+    const auto& ket       = braket.ket();
+
+    tensor t;
+    AODispatcher visitor(bra, ket, submods, t);
+    op.visit(visitor);
+
+    auto rv = results();
+    return pt::wrap_results(rv, std::move(t));
+}
+
+} // namespace scf::matrix_builder

--- a/src/scf/matrix_builder/fock.cpp
+++ b/src/scf/matrix_builder/fock.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "matrix_builder.hpp"
 
 namespace scf::matrix_builder {

--- a/src/scf/matrix_builder/fock.cpp
+++ b/src/scf/matrix_builder/fock.cpp
@@ -1,0 +1,24 @@
+// #include "matrix_builders.hpp"
+
+// namespace scf::matrix_builders {
+
+// using pt             = simde::aos_f_e_aos;
+// using op_base        = chemist::qm_operator::OperatorBase;
+// using aos            = simde::type::aos;
+// using aos_squared    = simde::type::aos_squared;
+// using braket_type_2c = simde::type::braket<aos, op_base aos>;
+// using braket_type_4c = simde::type::braket<aos_squared, op_base,
+// aos_squared>; using pt_2c          = simde::EvaluateBraKet<braket_type_2c>;
+// using pt_4c          = simde::EvaluateBraKet<braket_type_4c>;
+
+// const auto desc = R"(
+// )";
+
+// MODULE_CTOR(Fock) {
+//     description(desc);
+//     satisfies_property_type<pt>();
+//     add_submodule<pt_2c>("Two center evaluator");
+//     add_submodule<pt_4c>("Four center evaluator");
+// }
+
+// } // namespace scf::matrix_builders

--- a/src/scf/matrix_builder/fock.cpp
+++ b/src/scf/matrix_builder/fock.cpp
@@ -1,24 +1,55 @@
-// #include "matrix_builders.hpp"
+#include "matrix_builder.hpp"
 
-// namespace scf::matrix_builders {
+namespace scf::matrix_builder {
+namespace {
 
-// using pt             = simde::aos_f_e_aos;
-// using op_base        = chemist::qm_operator::OperatorBase;
-// using aos            = simde::type::aos;
-// using aos_squared    = simde::type::aos_squared;
-// using braket_type_2c = simde::type::braket<aos, op_base aos>;
-// using braket_type_4c = simde::type::braket<aos_squared, op_base,
-// aos_squared>; using pt_2c          = simde::EvaluateBraKet<braket_type_2c>;
-// using pt_4c          = simde::EvaluateBraKet<braket_type_4c>;
+const auto desc = R"(
+)";
 
-// const auto desc = R"(
-// )";
+}
 
-// MODULE_CTOR(Fock) {
-//     description(desc);
-//     satisfies_property_type<pt>();
-//     add_submodule<pt_2c>("Two center evaluator");
-//     add_submodule<pt_4c>("Four center evaluator");
-// }
+using pt    = simde::aos_f_e_aos;
+using ao_pt = simde::aos_op_base_aos;
 
-// } // namespace scf::matrix_builders
+MODULE_CTOR(Fock) {
+    description(desc);
+    satisfies_property_type<pt>();
+    add_submodule<ao_pt>("Two center evaluator");
+}
+
+MODULE_RUN(Fock) {
+    const auto&& [braket] = pt::unwrap_inputs(inputs);
+    const auto& bra_aos   = braket.bra();
+    const auto& f         = braket.op();
+    const auto& ket_aos   = braket.ket();
+    auto& ao_dispatcher   = submods.at("Two center evaluator");
+
+    simde::type::tensor F;
+    auto n_terms = f.size();
+    if(n_terms > 0) {
+        // Initialize F to zero-th term
+        const auto c0    = f.coefficient(0);
+        const auto& op_0 = f.get_operator(0);
+        chemist::braket::BraKet term0(bra_aos, op_0, ket_aos);
+        F = ao_dispatcher.run_as<ao_pt>(term0);
+
+        using allocator_type = tensorwrapper::allocator::Eigen<double, 2>;
+        auto& f_buffer       = allocator_type::rebind(F.buffer());
+        f_buffer.value()     = f_buffer.value() * c0;
+
+        for(decltype(n_terms) i = 1; i < n_terms; ++i) {
+            const auto ci    = f.coefficient(i);
+            const auto& op_i = f.get_operator(i);
+            chemist::braket::BraKet termi(bra_aos, op_i, ket_aos);
+            auto matrix = ao_dispatcher.run_as<ao_pt>(termi);
+
+            auto& matrix_buffer = allocator_type::rebind(matrix.buffer());
+            f_buffer.value() += ci * matrix_buffer.value();
+        }
+    }
+
+    auto rv = results();
+    return pt::wrap_results(rv, F);
+}
+
+} // namespace scf::matrix_builder

--- a/src/scf/matrix_builder/j_four_center.cpp
+++ b/src/scf/matrix_builder/j_four_center.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "matrix_builder.hpp"
 
 namespace scf::matrix_builder {

--- a/src/scf/matrix_builder/j_four_center.cpp
+++ b/src/scf/matrix_builder/j_four_center.cpp
@@ -1,0 +1,64 @@
+#include "matrix_builder.hpp"
+
+namespace scf::matrix_builder {
+
+using pt    = simde::aos_j_e_aos;
+using pt_4c = simde::ERI4;
+
+auto desc = R"(
+Four-Center J Builder
+---------------------
+)";
+
+MODULE_CTOR(JFourCenter) {
+    description(desc);
+    satisfies_property_type<pt>();
+    add_submodule<pt_4c>("Four-center ERI");
+}
+
+MODULE_RUN(JFourCenter) {
+    const auto&& [braket] = pt::unwrap_inputs(inputs);
+    // TODO: avoid copying AOs
+    simde::type::aos bra_e0 = braket.bra();
+    const auto& j_hat       = braket.op();
+    simde::type::aos ket_e0 = braket.ket();
+    const auto& rho         = j_hat.rhs_particle();
+    simde::type::aos aos_e1 = rho.basis_set();
+    const auto& p           = rho.value();
+    auto& eri_mod           = submods.at("Four-center ERI");
+
+    // auto aos2_v_aos2 = (aos_e1 * aos_e1 | v_ee | bra_e0 * ket_e0);
+    simde::type::v_ee_type v_ee;
+    simde::type::aos_squared e1_pair(aos_e1, aos_e1);
+    simde::type::aos_squared e2_pair(bra_e0, ket_e0);
+    chemist::braket::BraKet aos2_v_aos2(e1_pair, v_ee, e2_pair);
+    const auto& I = eri_mod.run_as<pt_4c>(std::move(aos2_v_aos2));
+
+    // This goes away when j("m,n") = p("l,s")*I("l,s,m,n") works
+    // {
+    using eri_alloc  = tensorwrapper::allocator::Eigen<double, 4>;
+    using rho_alloc  = tensorwrapper::allocator::Eigen<double, 2>;
+    using index_pair = Eigen::IndexPair<int>;
+    using array_t    = Eigen::array<index_pair, 2>;
+
+    const auto& I_eigen  = eri_alloc::rebind(I.buffer()).value();
+    const auto& p_buffer = rho_alloc::rebind(p.buffer());
+    const auto& p_eigen  = p_buffer.value();
+
+    array_t contract_modes{index_pair{0, 0}, index_pair(1, 1)};
+    using eigen_buffer_type = typename rho_alloc::eigen_buffer_type;
+    using eigen_tensor_type = typename eigen_buffer_type::data_type;
+
+    eigen_tensor_type j_eigen = I_eigen.contract(p_eigen, contract_modes);
+    auto j_buffer = std::make_unique<eigen_buffer_type>(std::move(j_eigen),
+                                                        p_buffer.layout());
+
+    using logical_type = tensorwrapper::layout::Logical;
+    auto playout       = p.logical_layout().clone_as<logical_type>();
+    simde::type::tensor j(std::move(playout), std::move(j_buffer));
+    //}
+    auto rv = results();
+    return pt::wrap_results(rv, std::move(j));
+}
+
+} // namespace scf::matrix_builder

--- a/src/scf/matrix_builder/k_four_center.cpp
+++ b/src/scf/matrix_builder/k_four_center.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "matrix_builder.hpp"
 
 namespace scf::matrix_builder {

--- a/src/scf/matrix_builder/k_four_center.cpp
+++ b/src/scf/matrix_builder/k_four_center.cpp
@@ -2,42 +2,43 @@
 
 namespace scf::matrix_builder {
 
-using pt    = simde::aos_j_e_aos;
+using pt    = simde::aos_k_e_aos;
 using pt_4c = simde::ERI4;
 
 namespace {
 
 auto desc = R"(
-Four-Center J Builder
+Four-Center K Builder
 ---------------------
 )";
 
 }
-MODULE_CTOR(JFourCenter) {
+
+MODULE_CTOR(KFourCenter) {
     description(desc);
     satisfies_property_type<pt>();
     add_submodule<pt_4c>("Four-center ERI");
 }
 
-MODULE_RUN(JFourCenter) {
+MODULE_RUN(KFourCenter) {
     const auto&& [braket] = pt::unwrap_inputs(inputs);
     // TODO: avoid copying AOs
     simde::type::aos bra_e0 = braket.bra();
-    const auto& j_hat       = braket.op();
+    const auto& k_hat       = braket.op();
     simde::type::aos ket_e0 = braket.ket();
-    const auto& rho         = j_hat.rhs_particle();
+    const auto& rho         = k_hat.rhs_particle();
     simde::type::aos aos_e1 = rho.basis_set();
     const auto& p           = rho.value();
     auto& eri_mod           = submods.at("Four-center ERI");
 
-    // auto aos2_v_aos2 = (bra_e0 * ket_e0 | v_ee | aos_e1 * aos_e1);
+    // auto aos2_v_aos2 = (bra_e0 * aos_e1 | v_ee | aos_e1 * ket_e0);
     simde::type::v_ee_type v_ee;
-    simde::type::aos_squared e0_pair(bra_e0, ket_e0);
-    simde::type::aos_squared e1_pair(aos_e1, aos_e1);
+    simde::type::aos_squared e0_pair(bra_e0, aos_e1);
+    simde::type::aos_squared e1_pair(aos_e1, ket_e0);
     chemist::braket::BraKet aos2_v_aos2(e0_pair, v_ee, e1_pair);
     const auto& I = eri_mod.run_as<pt_4c>(std::move(aos2_v_aos2));
 
-    // This goes away when j("m,n") = p("l,s")*I("m,n,s,l") works
+    // This goes away when k("m,n") = p("l,s")*I("m,l,s,n") works
     // {
     using eri_alloc  = tensorwrapper::allocator::Eigen<double, 4>;
     using rho_alloc  = tensorwrapper::allocator::Eigen<double, 2>;
@@ -48,20 +49,20 @@ MODULE_RUN(JFourCenter) {
     const auto& p_buffer = rho_alloc::rebind(p.buffer());
     const auto& p_eigen  = p_buffer.value();
 
-    array_t contract_modes{index_pair{0, 3}, index_pair(1, 2)};
+    array_t contract_modes{index_pair{0, 1}, index_pair(1, 2)};
     using eigen_buffer_type = typename rho_alloc::eigen_buffer_type;
     using eigen_tensor_type = typename eigen_buffer_type::data_type;
 
-    eigen_tensor_type j_eigen = p_eigen.contract(I_eigen, contract_modes);
-    auto j_buffer = std::make_unique<eigen_buffer_type>(std::move(j_eigen),
+    eigen_tensor_type k_eigen = p_eigen.contract(I_eigen, contract_modes);
+    auto k_buffer = std::make_unique<eigen_buffer_type>(std::move(k_eigen),
                                                         p_buffer.layout());
 
     using logical_type = tensorwrapper::layout::Logical;
     auto playout       = p.logical_layout().clone_as<logical_type>();
-    simde::type::tensor j(std::move(playout), std::move(j_buffer));
+    simde::type::tensor k(std::move(playout), std::move(k_buffer));
     //}
     auto rv = results();
-    return pt::wrap_results(rv, std::move(j));
+    return pt::wrap_results(rv, std::move(k));
 }
 
 } // namespace scf::matrix_builder

--- a/src/scf/matrix_builder/matrix_builder.hpp
+++ b/src/scf/matrix_builder/matrix_builder.hpp
@@ -3,14 +3,26 @@
 
 namespace scf::matrix_builder {
 
-// DECLARE_MODULE(Core);
-// DECLARE_MODULE(Fock);
+DECLARE_MODULE(AOIntegralsDriver);
+DECLARE_MODULE(Fock);
 DECLARE_MODULE(JFourCenter);
+DECLARE_MODULE(KFourCenter);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {
-    // mm.add_module<Core>("Core Matrix Builder");
-    // mm.add_module<Fock>("Fock matrix builder");
+    mm.add_module<AOIntegralsDriver>("AO integral driver");
+    mm.add_module<Fock>("Fock matrix builder");
     mm.add_module<JFourCenter>("Four center J builder");
+    mm.add_module<KFourCenter>("Four center K builder");
+}
+
+inline void set_defaults(pluginplay::ModuleManager& mm) {
+    const auto ao_driver = "AO integral driver";
+    mm.change_submod(ao_driver, "Coulomb matrix", "Four center J builder");
+    mm.change_submod(ao_driver, "Exchange matrix", "Four center K builder");
+    // TODO: Re-enable when PluginPlay doesn't choke on loops in modules
+    // mm.change_submod(ao_driver, "Fock matrix", "Fock Matrix Builder");
+
+    mm.change_submod("Fock matrix builder", "Two center evaluator", ao_driver);
 }
 
 } // namespace scf::matrix_builder

--- a/src/scf/matrix_builder/matrix_builder.hpp
+++ b/src/scf/matrix_builder/matrix_builder.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <simde/simde.hpp>
 

--- a/src/scf/matrix_builder/matrix_builder.hpp
+++ b/src/scf/matrix_builder/matrix_builder.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <simde/simde.hpp>
+
+namespace scf::matrix_builder {
+
+// DECLARE_MODULE(Core);
+// DECLARE_MODULE(Fock);
+DECLARE_MODULE(JFourCenter);
+
+inline void load_modules(pluginplay::ModuleManager& mm) {
+    // mm.add_module<Core>("Core Matrix Builder");
+    // mm.add_module<Fock>("Fock matrix builder");
+    mm.add_module<JFourCenter>("Four center J builder");
+}
+
+} // namespace scf::matrix_builder

--- a/src/scf/scf_mm.cpp
+++ b/src/scf/scf_mm.cpp
@@ -30,12 +30,15 @@ void load_modules(pluginplay::ModuleManager& mm) {
     guess::load_modules(mm);
     matrix_builder::load_modules(mm);
     update::load_modules(mm);
+
     mm.add_module<CoulombsLaw>("Coulomb's Law");
 #ifdef BUILD_TAMM_SCF
     mm.add_module<TAMMEnergy>("SCF Energy via TAMM");
 #endif
 
     guess::set_defaults(mm);
+    matrix_builder::set_defaults(mm);
+    update::set_defaults(mm);
 }
 
 } // namespace scf

--- a/src/scf/scf_mm.cpp
+++ b/src/scf/scf_mm.cpp
@@ -17,6 +17,7 @@
 #include "eigen_solver/eigen_solver.hpp"
 #include "fock_operator/fock_operator.hpp"
 #include "guess/guess.hpp"
+#include "matrix_builder/matrix_builder.hpp"
 #include "scf_modules.hpp"
 #include "update/update.hpp"
 #include <scf/scf_mm.hpp>
@@ -27,6 +28,7 @@ void load_modules(pluginplay::ModuleManager& mm) {
     eigen_solver::load_modules(mm);
     fock_operator::load_modules(mm);
     guess::load_modules(mm);
+    matrix_builder::load_modules(mm);
     update::load_modules(mm);
     mm.add_module<CoulombsLaw>("Coulomb's Law");
 #ifdef BUILD_TAMM_SCF

--- a/src/scf/scf_mm.cpp
+++ b/src/scf/scf_mm.cpp
@@ -16,7 +16,9 @@
 
 #include "eigen_solver/eigen_solver.hpp"
 #include "fock_operator/fock_operator.hpp"
+#include "guess/guess.hpp"
 #include "scf_modules.hpp"
+#include "update/update.hpp"
 #include <scf/scf_mm.hpp>
 
 namespace scf {
@@ -24,10 +26,14 @@ namespace scf {
 void load_modules(pluginplay::ModuleManager& mm) {
     eigen_solver::load_modules(mm);
     fock_operator::load_modules(mm);
+    guess::load_modules(mm);
+    update::load_modules(mm);
     mm.add_module<CoulombsLaw>("Coulomb's Law");
 #ifdef BUILD_TAMM_SCF
     mm.add_module<TAMMEnergy>("SCF Energy via TAMM");
 #endif
+
+    guess::set_defaults(mm);
 }
 
 } // namespace scf

--- a/src/scf/update/diagonalization.cpp
+++ b/src/scf/update/diagonalization.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "update.hpp"
 
 namespace scf::update {

--- a/src/scf/update/diagonalization.cpp
+++ b/src/scf/update/diagonalization.cpp
@@ -1,0 +1,45 @@
+#include "update.hpp"
+
+namespace scf::update {
+
+using rscf_wf         = simde::type::rscf_wf;
+using fock_matrix_pt  = simde::aos_f_e_aos;
+using pt              = simde::UpdateGuess<rscf_wf>;
+using diagonalizer_pt = simde::GeneralizedEigenSolve;
+
+const auto desc = R"(
+)";
+
+MODULE_CTOR(Diagonalization) {
+    description(desc);
+    satisfies_property_type<pt>();
+    add_submodule<fock_matrix_pt>("Fock matrix builder");
+    add_submodule<diagonalizer_pt>("Diagonalizer");
+}
+
+MODULE_RUN(Diagonalization) {
+    // const auto&& [F, old_guess] = pt::unwrap_inputs(inputs);
+
+    // // To one-electron F
+    // const auto& aos       = old_guess.orbitals().from_space();
+    // auto& fock_matrix_mod = submods.at("Fock matrix builder");
+    // const auto& f_matrix  = fock_matrix_mod.run_as<fock_matrix_pt>(aos, f,
+    // aos);
+
+    // // Compute S
+    // Tensor s;
+
+    // // Diagonalize
+    // const auto& diagonalizer_mod = submods.at("Diagonalizer");
+    // const auto&& [evalues, evectors] =
+    //   diagonalizer_mod.run_as<diagonalizer_pt>(f_matrix, s);
+
+    // // Create new guess
+    // simde::type::cmos cmos(evalues, aos, evectors);
+    // rscf_wf new_guess(old_guess.orbital_indices(), cmos);
+
+    // auto rv = results();
+    // return pt::wrap_results(rv, new_guess);
+}
+
+} // namespace scf::update

--- a/src/scf/update/diagonalization.cpp
+++ b/src/scf/update/diagonalization.cpp
@@ -6,6 +6,7 @@ using rscf_wf         = simde::type::rscf_wf;
 using fock_matrix_pt  = simde::aos_f_e_aos;
 using pt              = simde::UpdateGuess<rscf_wf>;
 using diagonalizer_pt = simde::GeneralizedEigenSolve;
+using s_pt            = simde::aos_s_e_aos;
 
 const auto desc = R"(
 )";
@@ -15,31 +16,34 @@ MODULE_CTOR(Diagonalization) {
     satisfies_property_type<pt>();
     add_submodule<fock_matrix_pt>("Fock matrix builder");
     add_submodule<diagonalizer_pt>("Diagonalizer");
+    add_submodule<s_pt>("Overlap matrix builder");
 }
 
 MODULE_RUN(Diagonalization) {
-    // const auto&& [F, old_guess] = pt::unwrap_inputs(inputs);
+    const auto&& [f, old_guess] = pt::unwrap_inputs(inputs);
+    const auto& aos             = old_guess.orbitals().from_space();
 
-    // // To one-electron F
-    // const auto& aos       = old_guess.orbitals().from_space();
-    // auto& fock_matrix_mod = submods.at("Fock matrix builder");
-    // const auto& f_matrix  = fock_matrix_mod.run_as<fock_matrix_pt>(aos, f,
-    // aos);
+    // Comput F
+    chemist::braket::BraKet f_mn(aos, f, aos);
+    auto& fock_matrix_mod = submods.at("Fock matrix builder");
+    const auto& f_matrix  = fock_matrix_mod.run_as<fock_matrix_pt>(f_mn);
 
-    // // Compute S
-    // Tensor s;
+    // Compute S
+    chemist::braket::BraKet s_mn(aos, simde::type::s_e_type{}, aos);
+    auto& s_mod          = submods.at("Overlap matrix builder");
+    const auto& s_matrix = s_mod.run_as<s_pt>(s_mn);
 
-    // // Diagonalize
-    // const auto& diagonalizer_mod = submods.at("Diagonalizer");
-    // const auto&& [evalues, evectors] =
-    //   diagonalizer_mod.run_as<diagonalizer_pt>(f_matrix, s);
+    // Diagonalize
+    auto& diagonalizer_mod = submods.at("Diagonalizer");
+    const auto&& [evalues, evectors] =
+      diagonalizer_mod.run_as<diagonalizer_pt>(f_matrix, s_matrix);
 
-    // // Create new guess
-    // simde::type::cmos cmos(evalues, aos, evectors);
-    // rscf_wf new_guess(old_guess.orbital_indices(), cmos);
+    // Create new guess
+    simde::type::cmos cmos(evalues, aos, evectors);
+    rscf_wf new_guess(old_guess.orbital_indices(), cmos);
 
-    // auto rv = results();
-    // return pt::wrap_results(rv, new_guess);
+    auto rv = results();
+    return pt::wrap_results(rv, new_guess);
 }
 
 } // namespace scf::update

--- a/src/scf/update/update.hpp
+++ b/src/scf/update/update.hpp
@@ -6,12 +6,14 @@ namespace scf::update {
 DECLARE_MODULE(Diagonalization);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {
-    mm.add_module<Diagonalization>("Diagonalization Fock update.");
+    mm.add_module<Diagonalization>("Diagonalization Fock update");
 }
 
 inline void set_defaults(pluginplay::ModuleManager& mm) {
     mm.change_submod("Diagonalization Fock update", "Diagonalizer",
                      "Generalized eigensolve via Eigen");
+    mm.change_submod("Diagonalization Fock update", "Fock matrix builder",
+                     "Fock matrix builder");
 }
 
 } // namespace scf::update

--- a/src/scf/update/update.hpp
+++ b/src/scf/update/update.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <simde/simde.hpp>
 

--- a/src/scf/update/update.hpp
+++ b/src/scf/update/update.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <simde/simde.hpp>
+
+namespace scf::update {
+
+DECLARE_MODULE(Diagonalization);
+
+inline void load_modules(pluginplay::ModuleManager& mm) {
+    mm.add_module<Diagonalization>("Diagonalization Fock update.");
+}
+
+inline void set_defaults(pluginplay::ModuleManager& mm) {
+    mm.change_submod("Diagonalization Fock update", "Diagonalizer",
+                     "Generalized eigensolve via Eigen");
+}
+
+} // namespace scf::update

--- a/tests/cxx/integration_tests/guess/core.cpp
+++ b/tests/cxx/integration_tests/guess/core.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../integration_tests.hpp"
+
+using rscf_wf = simde::type::rscf_wf;
+using pt      = simde::InitialGuess<rscf_wf>;
+using simde::type::tensor;
+
+TEST_CASE("Core") {
+    auto mm  = test_scf::load_modules();
+    auto aos = test_scf::h2_aos();
+    auto H   = test_scf::h2_hamiltonian();
+
+    auto mod = mm.at("Core guess");
+    auto psi = mod.run_as<pt>(H, aos);
+
+    typename rscf_wf::orbital_index_set_type occs{0};
+    REQUIRE(psi.orbital_indices() == occs);
+    REQUIRE(psi.orbitals().from_space() == aos);
+    const auto& evals       = psi.orbitals().diagonalized_matrix();
+    using allocator_type    = tensorwrapper::allocator::Eigen<double, 1>;
+    const auto& eval_buffer = allocator_type::rebind(evals.buffer());
+
+    const auto tol = 1E-6;
+    using Catch::Matchers::WithinAbs;
+    REQUIRE_THAT(eval_buffer.value()(0), WithinAbs(-1.25330893, tol));
+    REQUIRE_THAT(eval_buffer.value()(1), WithinAbs(-0.47506974, tol));
+}

--- a/tests/cxx/integration_tests/integration_tests.hpp
+++ b/tests/cxx/integration_tests/integration_tests.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "../test_scf.hpp"
+#include <integrals/integrals.hpp>
+#include <scf/scf.hpp>
+#include <simde/simde.hpp>
+
+namespace test_scf {
+
+/// Factors out setting submodules for SCF plugin from other plugins
+inline auto load_modules() {
+    pluginplay::ModuleManager mm;
+    scf::load_modules(mm);
+    integrals::load_modules(mm);
+
+    mm.change_submod("Four center J builder", "Four-center ERI", "ERI4");
+    mm.change_submod("Four center K builder", "Four-center ERI", "ERI4");
+
+    const auto ao_driver_key = "AO integral driver";
+    mm.change_submod(ao_driver_key, "Kinetic", "Kinetic");
+    mm.change_submod(ao_driver_key, "Electron-Nuclear attraction", "Nuclear");
+
+    mm.change_submod("Diagonalization Fock update", "Overlap matrix builder",
+                     "Overlap");
+
+    return mm;
+}
+
+} // namespace test_scf

--- a/tests/cxx/integration_tests/integration_tests.hpp
+++ b/tests/cxx/integration_tests/integration_tests.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include "../test_scf.hpp"
 #include <integrals/integrals.hpp>

--- a/tests/cxx/integration_tests/matrix_builder/ao_integrals_driver.cpp
+++ b/tests/cxx/integration_tests/matrix_builder/ao_integrals_driver.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../integration_tests.hpp"
+
+using pt = simde::aos_op_base_aos;
+using simde::type::tensor;
+
+namespace {
+
+void compare_matrices(const tensor& A, const tensor& A_corr) {
+    using Catch::Matchers::WithinAbs;
+    using alloc_type          = tensorwrapper::allocator::Eigen<double, 2>;
+    const auto& A_buffer      = alloc_type::rebind(A.buffer());
+    const auto& A_corr_buffer = alloc_type::rebind(A_corr.buffer());
+    const auto& A_eigen       = A_buffer.value();
+    const auto& A_corr_eigen  = A_corr_buffer.value();
+
+    const auto tol = 1E-6;
+
+    REQUIRE_THAT(A_eigen(0, 0), WithinAbs(A_corr_eigen(0, 0), 1E-6));
+    REQUIRE_THAT(A_eigen(0, 1), WithinAbs(A_corr_eigen(0, 1), 1E-6));
+    REQUIRE_THAT(A_eigen(1, 0), WithinAbs(A_corr_eigen(1, 0), 1E-6));
+    REQUIRE_THAT(A_eigen(1, 1), WithinAbs(A_corr_eigen(1, 1), 1E-6));
+}
+
+} // namespace
+
+using erased_type =
+  chemist::braket::BraKet<simde::type::aos, simde::type::op_base_type,
+                          simde::type::aos>;
+
+TEST_CASE("AOIntegralsDriver") {
+    auto mm  = test_scf::load_modules();
+    auto aos = test_scf::h2_aos();
+    auto mod = mm.at("AO integral driver");
+    simde::type::electron e;
+    auto rho = test_scf::h2_density();
+
+    SECTION("Calling Kinetic") {
+        auto& tmod = mm.at("Kinetic");
+        simde::type::t_e_type t_e(e);
+        chemist::braket::BraKet braket(aos, t_e, aos);
+        erased_type copy_braket(braket);
+        const auto& T      = mod.run_as<pt>(copy_braket);
+        const auto& T_corr = tmod.run_as<simde::aos_t_e_aos>(braket);
+        compare_matrices(T, T_corr);
+    }
+
+    SECTION("Calling Electron-Nuclear Attraction") {
+        auto& tmod     = mm.at("Nuclear");
+        auto h2_nuclei = test_scf::make_h2<simde::type::nuclei>();
+        simde::type::v_en_type v_en(e, h2_nuclei);
+        chemist::braket::BraKet braket(aos, v_en, aos);
+        erased_type copy_braket(braket);
+        const auto& V      = mod.run_as<pt>(copy_braket);
+        const auto& V_corr = tmod.run_as<simde::aos_v_en_aos>(braket);
+        compare_matrices(V, V_corr);
+    }
+
+    SECTION("Calling J Matrix") {
+        auto& jmod = mm.at("Four center J builder");
+        simde::type::j_e_type j_e(e, rho);
+        chemist::braket::BraKet braket(aos, j_e, aos);
+        erased_type copy_braket(braket);
+        const auto& J      = mod.run_as<pt>(copy_braket);
+        const auto& J_corr = jmod.run_as<simde::aos_j_e_aos>(braket);
+        compare_matrices(J, J_corr);
+    }
+
+    SECTION("Calling K Matrix") {
+        auto& kmod = mm.at("Four center K builder");
+        simde::type::k_e_type k_e(e, rho);
+        chemist::braket::BraKet braket(aos, k_e, aos);
+        erased_type copy_braket(braket);
+        const auto& K      = mod.run_as<pt>(copy_braket);
+        const auto& K_corr = kmod.run_as<simde::aos_k_e_aos>(braket);
+        compare_matrices(K, K_corr);
+    }
+
+    // Re-enable when PluginPlay doesn't choke on loops in modules
+    // SECTION("Calling Fock Matrix") {
+    //     auto& fmod = mm.at("Fock matrix builder");
+    //     auto f_e   = test_scf::h2_fock<simde::type::electron>();
+    //     chemist::braket::BraKet braket(aos, f_e, aos);
+    //     erased_type copy_braket(braket);
+    //     const auto& F      = mod.run_as<pt>(copy_braket);
+    //     const auto& F_corr = fmod.run_as<simde::aos_f_e_aos>(braket);
+    //     compare_matrices(F, F_corr);
+    // }
+}

--- a/tests/cxx/integration_tests/matrix_builder/fock.cpp
+++ b/tests/cxx/integration_tests/matrix_builder/fock.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../integration_tests.hpp"
+
+using pt = simde::aos_f_e_aos;
+
+using simde::type::t_e_type;
+using simde::type::v_en_type;
+
+TEST_CASE("Fock Matrix Builder") {
+    auto mm   = test_scf::load_modules();
+    auto& mod = mm.at("Fock Matrix Builder");
+    auto aos  = test_scf::h2_aos();
+
+    SECTION("No J or K") {
+        auto h2 = test_scf::make_h2<simde::type::nuclei>();
+        simde::type::electron e;
+
+        simde::type::fock f_e;
+        f_e.emplace_back(1.0, std::make_unique<t_e_type>(e));
+        f_e.emplace_back(1.0, std::make_unique<v_en_type>(e, h2));
+        const auto& F = mod.run_as<pt>(chemist::braket::BraKet(aos, f_e, aos));
+
+        using alloc_type    = tensorwrapper::allocator::Eigen<double, 2>;
+        const auto& F_eigen = alloc_type::rebind(F.buffer());
+        using Catch::Matchers::WithinAbs;
+        REQUIRE_THAT(F_eigen.value()(0, 0), WithinAbs(-1.120958, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(0, 1), WithinAbs(-0.959374, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(1, 0), WithinAbs(-0.959374, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(1, 1), WithinAbs(-1.120958, 1E-6));
+    }
+
+    SECTION("With J and K") {
+        auto f_e = test_scf::h2_fock<simde::type::electron>();
+
+        const auto& F = mod.run_as<pt>(chemist::braket::BraKet(aos, f_e, aos));
+
+        using alloc_type    = tensorwrapper::allocator::Eigen<double, 2>;
+        const auto& F_eigen = alloc_type::rebind(F.buffer());
+
+        using Catch::Matchers::WithinAbs;
+        REQUIRE_THAT(F_eigen.value()(0, 0), WithinAbs(-0.319459, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(0, 1), WithinAbs(-0.571781, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(1, 0), WithinAbs(-0.571781, 1E-6));
+        REQUIRE_THAT(F_eigen.value()(1, 1), WithinAbs(-0.319459, 1E-6));
+    }
+}

--- a/tests/cxx/integration_tests/matrix_builder/j_four_center.cpp
+++ b/tests/cxx/integration_tests/matrix_builder/j_four_center.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../../test_scf.hpp"
+#include <integrals/integrals.hpp>
+#include <scf/scf.hpp>
+#include <simde/simde.hpp>
+
+using pt = simde::aos_j_e_aos;
+
+TEST_CASE("JFourCenter") {
+    pluginplay::ModuleManager mm;
+    scf::load_modules(mm);
+    integrals::load_modules(mm);
+
+    const auto key = "Four center J builder";
+    mm.change_submod(key, "Four-center ERI", "ERI4");
+    auto& mod = mm.at(key);
+    auto aos  = test_scf::h2_aos();
+    simde::type::j_e_type j_e(simde::type::electron{}, test_scf::h2_density());
+    const auto& J = mod.run_as<pt>(chemist::braket::BraKet(aos, j_e, aos));
+
+    using alloc_type    = tensorwrapper::allocator::Eigen<double, 2>;
+    const auto& J_eigen = alloc_type::rebind(J.buffer());
+    using Catch::Matchers::WithinAbs;
+    REQUIRE_THAT(J_eigen.value()(0, 0), WithinAbs(1.34730017024511817, 1E-6));
+    REQUIRE_THAT(J_eigen.value()(0, 1), WithinAbs(0.94385684622352084, 1E-6));
+    REQUIRE_THAT(J_eigen.value()(1, 0), WithinAbs(0.94385684622352084, 1E-6));
+    REQUIRE_THAT(J_eigen.value()(1, 1), WithinAbs(1.51620668964453786, 1E-6));
+}

--- a/tests/cxx/integration_tests/matrix_builder/k_four_center.cpp
+++ b/tests/cxx/integration_tests/matrix_builder/k_four_center.cpp
@@ -16,21 +16,21 @@
 
 #include "../integration_tests.hpp"
 
-using pt = simde::aos_j_e_aos;
+using pt = simde::aos_k_e_aos;
 
-TEST_CASE("JFourCenter") {
+TEST_CASE("KFourCenter") {
     auto mm   = test_scf::load_modules();
-    auto& mod = mm.at("Four center J builder");
+    auto& mod = mm.at("Four center K builder");
     auto aos  = test_scf::h2_aos();
 
-    simde::type::j_e_type j_e(simde::type::electron{}, test_scf::h2_density());
-    const auto& J = mod.run_as<pt>(chemist::braket::BraKet(aos, j_e, aos));
+    simde::type::k_e_type k_e(simde::type::electron{}, test_scf::h2_density());
+    const auto& K = mod.run_as<pt>(chemist::braket::BraKet(aos, k_e, aos));
 
     using alloc_type    = tensorwrapper::allocator::Eigen<double, 2>;
-    const auto& J_eigen = alloc_type::rebind(J.buffer());
+    const auto& K_eigen = alloc_type::rebind(K.buffer());
     using Catch::Matchers::WithinAbs;
-    REQUIRE_THAT(J_eigen.value()(0, 0), WithinAbs(0.71438149, 1E-6));
-    REQUIRE_THAT(J_eigen.value()(0, 1), WithinAbs(0.47471072, 1E-6));
-    REQUIRE_THAT(J_eigen.value()(1, 0), WithinAbs(0.47471072, 1E-6));
-    REQUIRE_THAT(J_eigen.value()(1, 1), WithinAbs(0.71438149, 1E-6));
+    REQUIRE_THAT(K_eigen.value()(0, 0), WithinAbs(0.627264, 1E-6));
+    REQUIRE_THAT(K_eigen.value()(0, 1), WithinAbs(0.561828, 1E-6));
+    REQUIRE_THAT(K_eigen.value()(1, 0), WithinAbs(0.561828, 1E-6));
+    REQUIRE_THAT(K_eigen.value()(1, 1), WithinAbs(0.627264, 1E-6));
 }

--- a/tests/cxx/integration_tests/test_scf.cpp
+++ b/tests/cxx/integration_tests/test_scf.cpp
@@ -21,54 +21,58 @@
 #include <iostream>
 #include <scf/scf.hpp>
 
+#ifdef BUILD_TAMM_SCF
+
 TEST_CASE("SCF") {
+    // Populate modules
+    pluginplay::ModuleManager mm;
+    chemcache::load_modules(mm);
+    scf::load_modules(mm);
 
-  // Populate modules
-  pluginplay::ModuleManager mm;
-  chemcache::load_modules(mm);
-  scf::load_modules(mm);
+    // Create ChemicalSystem
+    std::string mol_name = "water";
+    auto mol =
+      mm.at("NWX Molecules").run_as<simde::MoleculeFromString>(mol_name);
+    simde::type::chemical_system cs(mol);
 
-  // Create ChemicalSystem
-  std::string mol_name = "water";
-  auto mol = mm.at("NWX Molecules").run_as<simde::MoleculeFromString>(mol_name);
-  simde::type::chemical_system cs(mol);
-
-  // Create BasisSet
-  std::string basis_name =
+    // Create BasisSet
+    std::string basis_name =
       "sto-3g"; // This is the only supported basis in ChemCache
-  auto aos = mm.at(basis_name).run_as<simde::MolecularBasisSet>(mol);
+    auto aos = mm.at(basis_name).run_as<simde::MolecularBasisSet>(mol);
 
-  // Run module
-  mm.change_input("SCF Energy via TAMM", "molecule_name", mol_name);
-  auto E = mm.at("SCF Energy via TAMM").run_as<simde::AOEnergy>(aos, cs);
-  std::cout << "SCF Energy = " << E << " Hartree" << std::endl;
+    // Run module
+    mm.change_input("SCF Energy via TAMM", "molecule_name", mol_name);
+    auto E = mm.at("SCF Energy via TAMM").run_as<simde::AOEnergy>(aos, cs);
+    std::cout << "SCF Energy = " << E << " Hartree" << std::endl;
 
-  REQUIRE(E == Catch::Approx(-74.3670617803483).margin(1.0e-6));
+    REQUIRE(E == Catch::Approx(-74.3670617803483).margin(1.0e-6));
 }
 
 TEST_CASE("DFT") {
+    // Populate modules
+    pluginplay::ModuleManager mm;
+    chemcache::load_modules(mm);
+    scf::load_modules(mm);
 
-  // Populate modules
-  pluginplay::ModuleManager mm;
-  chemcache::load_modules(mm);
-  scf::load_modules(mm);
+    // Create ChemicalSystem
+    std::string mol_name = "water";
+    auto mol =
+      mm.at("NWX Molecules").run_as<simde::MoleculeFromString>(mol_name);
+    simde::type::chemical_system cs(mol);
 
-  // Create ChemicalSystem
-  std::string mol_name = "water";
-  auto mol = mm.at("NWX Molecules").run_as<simde::MoleculeFromString>(mol_name);
-  simde::type::chemical_system cs(mol);
-
-  // Create BasisSet
-  std::string basis_name =
+    // Create BasisSet
+    std::string basis_name =
       "sto-3g"; // This is the only supported basis in ChemCache
-  auto aos = mm.at(basis_name).run_as<simde::MolecularBasisSet>(mol);
+    auto aos = mm.at(basis_name).run_as<simde::MolecularBasisSet>(mol);
 
-  // Run module
-  std::vector<std::string> xc_type = {"pbe0"};
-  mm.change_input("SCF Energy via TAMM", "xc_type", xc_type);
-  mm.change_input("SCF Energy via TAMM", "molecule_name", mol_name);
-  auto E = mm.at("SCF Energy via TAMM").run_as<simde::AOEnergy>(aos, cs);
-  std::cout << "SCF Energy = " << E << " Hartree" << std::endl;
+    // Run module
+    std::vector<std::string> xc_type = {"pbe0"};
+    mm.change_input("SCF Energy via TAMM", "xc_type", xc_type);
+    mm.change_input("SCF Energy via TAMM", "molecule_name", mol_name);
+    auto E = mm.at("SCF Energy via TAMM").run_as<simde::AOEnergy>(aos, cs);
+    std::cout << "SCF Energy = " << E << " Hartree" << std::endl;
 
-  REQUIRE(E == Catch::Approx(-74.81168986385825).margin(1.0e-6));
+    REQUIRE(E == Catch::Approx(-74.81168986385825).margin(1.0e-6));
 }
+
+#endif

--- a/tests/cxx/integration_tests/update/diagonalization.cpp
+++ b/tests/cxx/integration_tests/update/diagonalization.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../integration_tests.hpp"
+
+using wf_t              = simde::type::rscf_wf;
+using pt                = simde::UpdateGuess<wf_t>;
+using orbital_index_set = typename wf_t::orbital_index_set_type;
+
+using simde::type::t_e_type;
+using simde::type::v_en_type;
+
+TEST_CASE("Diagaonalization") {
+    auto mm   = test_scf::load_modules();
+    auto& mod = mm.at("Diagonalization Fock update");
+
+    auto aos = test_scf::h2_aos();
+    auto h2  = test_scf::make_h2<simde::type::nuclei>();
+    simde::type::electron e;
+    orbital_index_set occs{0};
+
+    simde::type::fock f_e;
+    f_e.emplace_back(1.0, std::make_unique<t_e_type>(e));
+    f_e.emplace_back(1.0, std::make_unique<v_en_type>(e, h2));
+
+    SECTION("No old guess") {
+        simde::type::tensor empty;
+        simde::type::cmos cmos(empty, aos, empty);
+        simde::type::rscf_wf core_guess(occs, cmos);
+        const auto& psi = mod.run_as<pt>(f_e, core_guess);
+        REQUIRE(psi.orbital_indices() == occs);
+        REQUIRE(psi.orbitals().from_space() == aos);
+        const auto& evals       = psi.orbitals().diagonalized_matrix();
+        using allocator_type    = tensorwrapper::allocator::Eigen<double, 1>;
+        const auto& eval_buffer = allocator_type::rebind(evals.buffer());
+
+        const auto tol = 1E-6;
+        using Catch::Matchers::WithinAbs;
+        REQUIRE_THAT(eval_buffer.value()(0), WithinAbs(-1.25330893, tol));
+        REQUIRE_THAT(eval_buffer.value()(1), WithinAbs(-0.47506974, tol));
+    }
+}

--- a/tests/cxx/test_scf.hpp
+++ b/tests/cxx/test_scf.hpp
@@ -105,15 +105,26 @@ inline auto h2_density() {
 }
 
 /// The Fock matrix consistent with h2_hamiltonian and h2_density
+template<typename ElectronType>
 inline auto h2_fock() {
-    simde::type::many_electrons es(2);
+    ElectronType es;
+    if constexpr(std::is_same_v<ElectronType, simde::type::many_electrons>) {
+        es = simde::type::many_electrons(2);
+    }
+
     auto h2  = make_h2<simde::type::nuclei>();
     auto rho = h2_density();
     simde::type::fock F;
-    F.emplace_back(1.0, std::make_unique<simde::type::T_e_type>(es));
-    F.emplace_back(1.0, std::make_unique<simde::type::V_en_type>(es, h2));
-    F.emplace_back(2.0, std::make_unique<simde::type::J_e_type>(es, rho));
-    F.emplace_back(-1.0, std::make_unique<simde::type::K_e_type>(es, rho));
+    using namespace chemist::qm_operator;
+    using t_type = Kinetic<ElectronType>;
+    using v_type = Coulomb<ElectronType, chemist::Nuclei>;
+    using j_type = Coulomb<ElectronType, simde::type::decomposable_e_density>;
+    using k_type = Exchange<ElectronType, simde::type::decomposable_e_density>;
+
+    F.emplace_back(1.0, std::make_unique<t_type>(es));
+    F.emplace_back(1.0, std::make_unique<v_type>(es, h2));
+    F.emplace_back(2.0, std::make_unique<j_type>(es, rho));
+    F.emplace_back(-1.0, std::make_unique<k_type>(es, rho));
     return F;
 }
 

--- a/tests/cxx/test_scf.hpp
+++ b/tests/cxx/test_scf.hpp
@@ -100,7 +100,7 @@ inline auto h2_mos() {
 inline auto h2_density() {
     using density_type = simde::type::decomposable_e_density;
     typename density_type::value_type rho(
-      {{0.92501791, -0.54009707}, {-0.28540122, 1.7505162}});
+      {{0.31980835, 0.31980835}, {0.31980835, 0.31980835}});
     return density_type(rho, h2_mos());
 }
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
I did things out of order. While a core guess seems like it should be the next thing to implement, to do one you have to essentially need to be able to build a Fock matrix and do one update. In turn this PR: 

- Module for building Fock operator can now do the one-electron or many-electron version.
- Adds module for the core guess.
- Adds an integral driver module that takes an `OperatorBase` and dispatches accordingly (I'm leaning towards putting this in integrals, but it gets weird since it can compute Fock, J, and K matrices).
- Adds a module for computing the Fock matrix.
- Adds a module for computing J.
- Adds a module for computing K.
- Adds a module for updating the wavefunction given the current Fock matrix.

**TODOs**
- [x] Merge https://github.com/NWChemEx/SimDE/pull/157
- [x] Merge https://github.com/NWChemEx/NWChemEx/pull/141
