### PR TITLE
Bug in forming density

### DIFF
--- a/src/scf/matrix_builder/density_matrix.cpp
+++ b/src/scf/matrix_builder/density_matrix.cpp
@@ -36,7 +36,7 @@ struct Kernel {
         auto rv              = c.allocator().runtime();
         allocator_type alloc(rv);
 
-        tensorwrapper::shape::Smooth p_shape(n_aos, n_aos);
+        tensorwrapper::shape::Smooth p_shape{n_aos, n_aos};
         tensorwrapper::layout::Physical l(p_shape);
         auto pp_buffer = alloc.allocate(l);
 

--- a/tests/cxx/integration_tests/driver/scf_driver.cpp
+++ b/tests/cxx/integration_tests/driver/scf_driver.cpp
@@ -33,4 +33,18 @@ TEMPLATE_LIST_TEST_CASE("SCFDriver", "", test_scf::float_types) {
 
     const auto e = mm.template run_as<pt>("SCF Driver", aos, h2);
     REQUIRE(approximately_equal(corr, e, 1E-6));
+
+    SECTION("H2 Dimer") {
+        simde::type::nucleus h0("H", 1ul, 1836.15, 0.0, 0.0, 0.0);
+        simde::type::nucleus h1("H", 1ul, 1836.15, 0.0, 0.0, 1.39839);
+        simde::type::nucleus h2("H", 1ul, 1836.15, 0.0, 0.0, 4.39839);
+        simde::type::nucleus h3("H", 1ul, 1836.15, 0.0, 0.0, 5.79678);
+        simde::type::nuclei h2_dimer_nuclei{h0, h1, h2, h3};
+        auto ao_bs = test_scf::h_basis(h2_dimer_nuclei);
+        simde::type::molecule h2_dimer_mol(0, 1, h2_dimer_nuclei);
+        simde::type::chemical_system h2_dimer_sys(h2_dimer_mol);
+        const auto e =
+          mm.template run_as<pt>("SCF Driver", ao_bs, h2_dimer_sys);
+        std::cout << e << std::endl;
+    }
 }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
When creating the shape for the density matrix we did `Smooth(n_aos, n_aos)` instead of `Smooth{n_aos, n_aos}`. The former creates a rank `n_aos` tensor whose extents are all `n_aos` whereas the latter creates a rank 2 tensor with extents `n_aos`. We wanted the latter.

**TODOs**
None. R2g.
