### PR TITLE
Adds a fix for when the system is a single atom.

### DIFF
--- a/src/scf/driver/scf_loop.cpp
+++ b/src/scf/driver/scf_loop.cpp
@@ -70,7 +70,7 @@ struct GrabNuclear : chemist::qm_operator::OperatorVisitor {
 
     void run(const V_nn_type& V_nn) { m_pv = &V_nn; }
 
-    const V_nn_type* m_pv;
+    const V_nn_type* m_pv = nullptr;
 };
 
 MODULE_CTOR(SCFLoop) {

--- a/src/scf/driver/scf_loop.cpp
+++ b/src/scf/driver/scf_loop.cpp
@@ -204,19 +204,20 @@ MODULE_RUN(SCFLoop) {
 
             // Change in the density
             simde::type::tensor dp;
-            dp("m,n")    = rho_new.value()("m,n") - rho_old.value()("m,n");
-            auto dp_norm = tensorwrapper::operations::infinity_norm(dp);
+            const auto& P_old = rho_old.value();
+            dp("m,n")         = rho_new.value()("m,n") - P_old("m,n");
+            auto dp_norm      = tensorwrapper::operations::infinity_norm(dp);
 
             // Orbital gradient: FPS-SPF
             // TODO: module satisfying BraKet(aos, Commutator(F,P), aos)
             chemist::braket::BraKet F_mn(aos, f_new, aos);
             const auto& F_matrix = F_mod.run_as<fock_matrix_pt>(F_mn);
             simde::type::tensor FPS;
-            FPS("m,l") = F_matrix("m,n") * P_new("n,l");
+            FPS("m,l") = F_matrix("m,n") * P_old("n,l");
             FPS("m,l") = FPS("m,n") * S("n,l");
 
             simde::type::tensor SPF;
-            SPF("m,l") = P_new("m,n") * F_matrix("n,l");
+            SPF("m,l") = P_old("m,n") * F_matrix("n,l");
             SPF("m,l") = S("m,n") * SPF("n,l");
 
             simde::type::tensor grad;

--- a/src/scf/driver/scf_loop.cpp
+++ b/src/scf/driver/scf_loop.cpp
@@ -118,21 +118,26 @@ MODULE_RUN(SCFLoop) {
     // Step 1: Nuclear-nuclear repulsion
     GrabNuclear visitor;
     H.visit(visitor);
+    bool has_nn = (H.m_pv != nullptr);
+
     // TODO: Clean up charges class to make this easier...
-    const auto& V_nn       = *visitor.m_pv;
-    const auto n_lhs       = V_nn.lhs_particle().as_nuclei();
-    const auto qs_lhs_view = n_lhs.charges();
-    const auto n_rhs       = V_nn.rhs_particle().as_nuclei();
-    const auto qs_rhs_view = n_rhs.charges();
-    simde::type::charges qs_lhs;
-    simde::type::charges qs_rhs;
-    for(const auto q_i : qs_lhs_view) {
-        qs_lhs.push_back(q_i.as_point_charge());
+    simde::type::tensor e_nuclear(0.0);
+    if(has_nn) {
+        const auto& V_nn       = *visitor.m_pv;
+        const auto n_lhs       = V_nn.lhs_particle().as_nuclei();
+        const auto qs_lhs_view = n_lhs.charges();
+        const auto n_rhs       = V_nn.rhs_particle().as_nuclei();
+        const auto qs_rhs_view = n_rhs.charges();
+        simde::type::charges qs_lhs;
+        simde::type::charges qs_rhs;
+        for(const auto q_i : qs_lhs_view) {
+            qs_lhs.push_back(q_i.as_point_charge());
+        }
+        for(const auto q_i : qs_rhs_view) {
+            qs_rhs.push_back(q_i.as_point_charge());
+        }
+        e_nuclear = V_nn_mod.run_as<v_nn_pt>(qs_lhs, qs_rhs);
     }
-    for(const auto q_i : qs_rhs_view) {
-        qs_rhs.push_back(q_i.as_point_charge());
-    }
-    auto e_nuclear = V_nn_mod.run_as<v_nn_pt>(qs_lhs, qs_rhs);
 
     // Compute S
     chemist::braket::BraKet s_mn(aos, simde::type::s_e_type{}, aos);
@@ -255,9 +260,9 @@ MODULE_RUN(SCFLoop) {
         ualloc.rebind(temp.buffer()).at() = val;
         e_nuclear                         = temp;
     }
-
     e_total("") = e_old("") + e_nuclear("");
-    auto rv     = results();
+
+    auto rv = results();
     return pt<wf_type>::wrap_results(rv, e_total, psi_old);
 }
 

--- a/src/scf/driver/scf_loop.cpp
+++ b/src/scf/driver/scf_loop.cpp
@@ -118,7 +118,7 @@ MODULE_RUN(SCFLoop) {
     // Step 1: Nuclear-nuclear repulsion
     GrabNuclear visitor;
     H.visit(visitor);
-    bool has_nn = (H.m_pv != nullptr);
+    bool has_nn = (visitor.m_pv != nullptr);
 
     // TODO: Clean up charges class to make this easier...
     simde::type::tensor e_nuclear(0.0);

--- a/tests/cxx/integration_tests/driver/scf_loop.cpp
+++ b/tests/cxx/integration_tests/driver/scf_loop.cpp
@@ -35,15 +35,19 @@ TEMPLATE_LIST_TEST_CASE("SCFLoop", "", test_scf::float_types) {
     auto pcorr = alloc.allocate(tensorwrapper::layout::Physical(shape_corr));
     using tensorwrapper::operations::approximately_equal;
 
-    using index_set = typename wf_type::orbital_index_set_type;
-    wf_type psi0(index_set{0}, test_scf::h2_cmos<float_type>());
+    SECTION("H2") {
+        using index_set = typename wf_type::orbital_index_set_type;
+        wf_type psi0(index_set{0}, test_scf::h2_cmos<float_type>());
 
-    auto H = test_scf::h2_hamiltonian();
+        auto H = test_scf::h2_hamiltonian();
 
-    chemist::braket::BraKet H_00(psi0, H, psi0);
-    const auto& [e, psi] = mod.template run_as<pt<wf_type>>(H_00, psi0);
+        chemist::braket::BraKet H_00(psi0, H, psi0);
+        const auto& [e, psi] = mod.template run_as<pt<wf_type>>(H_00, psi0);
 
-    pcorr->at() = -1.1167592336;
-    tensorwrapper::Tensor corr(shape_corr, std::move(pcorr));
-    REQUIRE(approximately_equal(corr, e, 1E-6));
+        pcorr->at() = -1.1167592336;
+        tensorwrapper::Tensor corr(shape_corr, std::move(pcorr));
+        REQUIRE(approximately_equal(corr, e, 1E-6));
+    }
+
+    SECTION("He") {}
 }

--- a/tests/cxx/integration_tests/driver/scf_loop.cpp
+++ b/tests/cxx/integration_tests/driver/scf_loop.cpp
@@ -27,8 +27,10 @@ using pt = simde::Optimize<egy_pt<WFType>, WFType>;
 TEMPLATE_LIST_TEST_CASE("SCFLoop", "", test_scf::float_types) {
     using float_type = TestType;
     using wf_type    = simde::type::rscf_wf;
-    auto mm          = test_scf::load_modules<float_type>();
-    auto& mod        = mm.at("Loop");
+    using index_set  = typename wf_type::orbital_index_set_type;
+
+    auto mm   = test_scf::load_modules<float_type>();
+    auto& mod = mm.at("Loop");
 
     tensorwrapper::allocator::Eigen<float_type> alloc(mm.get_runtime());
     tensorwrapper::shape::Smooth shape_corr{};
@@ -36,9 +38,7 @@ TEMPLATE_LIST_TEST_CASE("SCFLoop", "", test_scf::float_types) {
     using tensorwrapper::operations::approximately_equal;
 
     SECTION("H2") {
-        using index_set = typename wf_type::orbital_index_set_type;
         wf_type psi0(index_set{0}, test_scf::h2_cmos<float_type>());
-
         auto H = test_scf::h2_hamiltonian();
 
         chemist::braket::BraKet H_00(psi0, H, psi0);
@@ -49,5 +49,16 @@ TEMPLATE_LIST_TEST_CASE("SCFLoop", "", test_scf::float_types) {
         REQUIRE(approximately_equal(corr, e, 1E-6));
     }
 
-    SECTION("He") {}
+    SECTION("He") {
+        wf_type psi0(index_set{0}, test_scf::he_cmos<float_type>());
+
+        auto H = test_scf::he_hamiltonian();
+
+        chemist::braket::BraKet H_00(psi0, H, psi0);
+        const auto& [e, psi] = mod.template run_as<pt<wf_type>>(H_00, psi0);
+
+        pcorr->at() = -2.807783957539;
+        tensorwrapper::Tensor corr(shape_corr, std::move(pcorr));
+        REQUIRE(approximately_equal(corr, e, 1E-6));
+    }
 }

--- a/tests/cxx/test_scf.hpp
+++ b/tests/cxx/test_scf.hpp
@@ -30,6 +30,10 @@ inline auto h_nucleus(double x, double y, double z) {
     return simde::type::nucleus("H", 1ul, 1836.15, x, y, z);
 }
 
+inline auto he_nucleus(double x, double y, double z) {
+    return simde::type::nucleus("He", 2ul, 7344.61, x, y, z);
+}
+
 template<typename ResultType>
 ResultType make_h2() {
     using simde::type::chemical_system;
@@ -43,6 +47,25 @@ ResultType make_h2() {
         return molecule(0, 1, make_h2<nuclei>());
     } else if constexpr(std::is_same_v<ResultType, chemical_system>) {
         return chemical_system(make_h2<molecule>());
+    } else {
+        // We know this assert fails if we're in the else statement
+        // Getting here means you provided a bad type.
+        static_assert(std::is_same_v<ResultType, nuclei>);
+    }
+}
+
+template<typename ResultType>
+ResultType make_he() {
+    using simde::type::chemical_system;
+    using simde::type::molecule;
+    using simde::type::nuclei;
+    if constexpr(std::is_same_v<ResultType, nuclei>) {
+        auto he0 = he_nucleus(0.0, 0.0, 0.0);
+        return nuclei{he0};
+    } else if constexpr(std::is_same_v<ResultType, molecule>) {
+        return molecule(0, 1, make_he<nuclei>());
+    } else if constexpr(std::is_same_v<ResultType, chemical_system>) {
+        return chemical_system(make_he<molecule>());
     } else {
         // We know this assert fails if we're in the else statement
         // Getting here means you provided a bad type.
@@ -78,6 +101,35 @@ inline auto h_basis(NucleiType& hydrogens) {
     return rv;
 }
 
+template<typename NucleiType>
+inline auto he_basis(NucleiType& heliums) {
+    using ao_basis_type            = chemist::basis_set::AOBasisSetD;
+    using atomic_basis_type        = typename ao_basis_type::value_type;
+    using shell_type               = typename atomic_basis_type::value_type;
+    using contracted_gaussian_type = typename shell_type::cg_type;
+    using center_type = typename atomic_basis_type::shell_traits::center_type;
+
+    std::vector<double> he_coefs{1.5432896730e-01, 5.3532814230e-01,
+                                 4.4463454220e-01};
+    std::vector<double> he_exps{6.3624213940e+00, 1.1589229990e+00,
+                                3.1364979150e-01};
+    auto cartesian = shell_type::pure_type::cartesian;
+    shell_type::angular_momentum_type l0{0};
+
+    ao_basis_type rv;
+    for(std::size_t i = 0; i < heliums.size(); ++i) {
+        const auto& hi = heliums[i];
+        center_type coords(hi.x(), hi.y(), hi.z());
+        contracted_gaussian_type he_cg(he_coefs.begin(), he_coefs.end(),
+                                       he_exps.begin(), he_exps.end(), coords);
+        atomic_basis_type he_basis("STO-3G", 1, coords);
+        he_basis.add_shell(cartesian, l0, he_cg);
+        rv.add_center(he_basis);
+    }
+
+    return rv;
+}
+
 inline auto h2_hamiltonian() {
     simde::type::many_electrons es(2);
     auto h2 = make_h2<simde::type::nuclei>();
@@ -86,6 +138,16 @@ inline auto h2_hamiltonian() {
     simde::type::V_ee_type V_ee(es, es);
     simde::type::V_nn_type V_nn(h2, h2);
     return simde::type::hamiltonian(T_e + V_en + V_ee + V_nn);
+}
+
+inline auto he_hamiltonian() {
+    simde::type::many_electrons es(2);
+    auto he = make_he<simde::type::nuclei>();
+    simde::type::T_e_type T_e(es);
+    simde::type::V_en_type V_en(es, he);
+    simde::type::V_ee_type V_ee(es, es);
+    return simde::type::hamiltonian(T_e + V_en + V_ee);
+    ;
 }
 
 inline auto h2_aos() {


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Right now SCF tries to compute the nuclear-nuclear repulsion for all systems, even if they only contain one nucleus. This PR adds a check so that it is only computed when there are multiple nuclei.

**TODOs**
- [x] Finish the tests
