### PR TITLE
Convergence module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # These are directories used by IDEs for storing settings
 .idea/
 .vscode/
+.cache/
 
 # These are common Python virtual enviornment directory names
 venv/

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <pluginplay/pluginplay.hpp>
 #include <simde/types.hpp>

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -19,24 +19,10 @@ TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, KernelType) {
                     .template add_field<simde::type::tensor>("S")
                     .template add_field<simde::type::fock>("Fock Operator")
                     .template add_field<chemist::wavefunction::AOs>("Wave Function")
+                    .template add_field<KernelType>("K")
                     .template add_field<double>("Energy Tolerance")
                     .template add_field<double>("Density Tolerance")
                     .template add_field<double>("Gradient Tolerance");
-
-    rv.at("New Energy").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Old Energy").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Fock Operator").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Wave Function").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Energy Tolerance").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Density Tolerance").set_description(
-      "The string identifying the desired molecule");
-    rv.at("Gradient Tolerance").set_description(
-      "The string identifying the desired molecule");
     return rv;
 }
 

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -44,16 +44,35 @@ DECLARE_PROPERTY_TYPE(ConvergenceProp);
 
 PROPERTY_TYPE_INPUTS(ConvergenceProp) {
     using wf_type = simde::type::rscf_wf;
-    auto rv     = pluginplay::declare_input().add_field<elec_egy_pt<wf_type>>("Energy");
-    rv.at("String").set_description(
+    auto rv     = pluginplay::declare_input()
+                    .add_field<BraKet::result_type>("New Energy")
+                    .add_field<elec_egy_pt<wf_type>>("Old Energy")
+                    .add_field<elec_egy_pt<wf_type>>("Fock Operator")
+                    .add_field<elec_egy_pt<wf_type>>("Wave Function")
+                    .add_field<double>("Energy Tolerance")
+                    .add_field<double>("Density Tolerance")
+                    .add_field<double>("Gradient Tolerance");
+
+    rv.at("New Energy").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Old Energy").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Fock Operator").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Wave Function").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Energy Tolerance").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Density Tolerance").set_description(
+      "The string identifying the desired molecule");
+    rv.at("Gradient Tolerance").set_description(
       "The string identifying the desired molecule");
     return rv;
 }
 
 PROPERTY_TYPE_RESULTS(ConvergenceProp) {
-    using mol_t = type::molecule;
-    auto rv     = pluginplay::declare_result().add_field<mol_t>("Molecule");
-    rv.at("Molecule")
+    auto rv     = pluginplay::declare_result().add_field<bool>("Convergence Status");
+    rv.at("Convergence Status")
       .set_description("The molecule corresponding to the input string");
     return rv;
 }

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -5,9 +5,11 @@
 
 namespace scf {
 
-DECLARE_PROPERTY_TYPE(ConvergenceProp);
+template<typename KernelType>
+DECLARE_TEMPLATED_PROPERTY_TYPE(ConvergenceProp, KernelType);
 
-PROPERTY_TYPE_INPUTS(ConvergenceProp) {
+template<typename KernelType>
+TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, KernelType) {
     auto rv     = pluginplay::declare_input()
                     .add_field<simde::type::tensor>("New Energy")
                     .template add_field<simde::type::tensor>("Old Energy")
@@ -38,7 +40,8 @@ PROPERTY_TYPE_INPUTS(ConvergenceProp) {
     return rv;
 }
 
-PROPERTY_TYPE_RESULTS(ConvergenceProp) {
+template<typename KernelType>
+TEMPLATED_PROPERTY_TYPE_RESULTS(ConvergenceProp, KernelType) {
     auto rv     = pluginplay::declare_result().add_field<bool>("Convergence Status");
     rv.at("Convergence Status")
       .set_description("The molecule corresponding to the input string");

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -1,27 +1,22 @@
 #pragma once
 #include <pluginplay/pluginplay.hpp>
+#include <simde/types.hpp>
+
 
 namespace scf {
 
-/** @brief The property type for modules that return a molecule from a string
- *         input.
- *
- * The usage of this property type can be pretty varied. Modules that satisfy
- * this property type could potentially produce a molecule from a string with
- * XYZ inputs, a SMILES string, or a molecule name outright.
- *
- */
+DECLARE_PROPERTY_TYPE(ConvergenceProp);
 
-template<typename EnergyProp, typename FockProp, typename WfProp>
-DECLARE_TEMPLATED_PROPERTY_TYPE(ConvergenceProp, EnergyProp, FockProp, WfProp);
-
-template<typename EnergyProp, typename FockProp, typename WfProp>
-TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
+PROPERTY_TYPE_INPUTS(ConvergenceProp) {
     auto rv     = pluginplay::declare_input()
-                    .add_field<EnergyProp>("New Energy")
-                    .template add_field<EnergyProp>("Old Energy")
-                    .template add_field<FockProp>("Fock Operator")
-                    .template add_field<WfProp>("Wave Function")
+                    .add_field<simde::type::tensor>("New Energy")
+                    .template add_field<simde::type::tensor>("Old Energy")
+                    .template add_field<chemist::DecomposableDensity<chemist::Electron>>("New Rho")
+                    .template add_field<chemist::DecomposableDensity<chemist::Electron>>("Old Rho")
+                    .template add_field<simde::type::tensor>("P_new")
+                    .template add_field<simde::type::tensor>("S")
+                    .template add_field<simde::type::fock>("Fock Operator")
+                    .template add_field<chemist::wavefunction::AOs>("Wave Function")
                     .template add_field<double>("Energy Tolerance")
                     .template add_field<double>("Density Tolerance")
                     .template add_field<double>("Gradient Tolerance");
@@ -43,8 +38,7 @@ TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
     return rv;
 }
 
-template<typename EnergyProp, typename FockProp, typename WfProp>
-TEMPLATED_PROPERTY_TYPE_RESULTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
+PROPERTY_TYPE_RESULTS(ConvergenceProp) {
     auto rv     = pluginplay::declare_result().add_field<bool>("Convergence Status");
     rv.at("Convergence Status")
       .set_description("The molecule corresponding to the input string");

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "simde/simde.hpp"
+#include <simde/simde.hpp>
 #include <pluginplay/pluginplay.hpp>
 
 namespace scf {
@@ -13,45 +13,20 @@ namespace scf {
  *
  */
 
-using simde::type::electronic_hamiltonian;
-using simde::type::hamiltonian;
-using simde::type::op_base_type;
+template<typename EnergyProp, typename FockProp, typename WfProp>
+DECLARE_TEMPLATED_PROPERTY_TYPE(ConvergenceProp, EnergyProp, FockProp, WfProp);
 
-template<typename WfType>
-using egy_pt = simde::eval_braket<WfType, hamiltonian, WfType>;
-
-template<typename WfType>
-using elec_egy_pt = simde::eval_braket<WfType, electronic_hamiltonian, WfType>;
-
-template<typename WfType>
-using pt = simde::Optimize<egy_pt<WfType>, WfType>;
-
-template<typename WfType>
-using update_pt = simde::UpdateGuess<WfType>;
-
-using density_t = simde::type::decomposable_e_density;
-
-using fock_pt = simde::FockOperator<density_t>;
-
-using density_pt = simde::aos_rho_e_aos<simde::type::cmos>;
-
-using v_nn_pt = simde::charge_charge_interaction;
-
-using fock_matrix_pt = simde::aos_f_e_aos;
-using s_pt           = simde::aos_s_e_aos;
- 
-DECLARE_PROPERTY_TYPE(ConvergenceProp);
-
-PROPERTY_TYPE_INPUTS(ConvergenceProp) {
+template<typename EnergyProp, typename FockProp, typename WfProp>
+TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
     using wf_type = simde::type::rscf_wf;
     auto rv     = pluginplay::declare_input()
-                    .add_field<BraKet::result_type>("New Energy")
-                    .add_field<elec_egy_pt<wf_type>>("Old Energy")
-                    .add_field<elec_egy_pt<wf_type>>("Fock Operator")
-                    .add_field<elec_egy_pt<wf_type>>("Wave Function")
-                    .add_field<double>("Energy Tolerance")
-                    .add_field<double>("Density Tolerance")
-                    .add_field<double>("Gradient Tolerance");
+                    .add_field<EnergyProp>("New Energy")
+                    .template add_field<EnergyProp>("Old Energy")
+                    .template add_field<FockProp>("Fock Operator")
+                    .template add_field<WfProp>("Wave Function")
+                    .template add_field<double>("Energy Tolerance")
+                    .template add_field<double>("Density Tolerance")
+                    .template add_field<double>("Gradient Tolerance");
 
     rv.at("New Energy").set_description(
       "The string identifying the desired molecule");
@@ -70,7 +45,8 @@ PROPERTY_TYPE_INPUTS(ConvergenceProp) {
     return rv;
 }
 
-PROPERTY_TYPE_RESULTS(ConvergenceProp) {
+template<typename EnergyProp, typename FockProp, typename WfProp>
+TEMPLATED_PROPERTY_TYPE_RESULTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
     auto rv     = pluginplay::declare_result().add_field<bool>("Convergence Status");
     rv.at("Convergence Status")
       .set_description("The molecule corresponding to the input string");

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <simde/simde.hpp>
 #include <pluginplay/pluginplay.hpp>
 
 namespace scf {
@@ -18,7 +17,6 @@ DECLARE_TEMPLATED_PROPERTY_TYPE(ConvergenceProp, EnergyProp, FockProp, WfProp);
 
 template<typename EnergyProp, typename FockProp, typename WfProp>
 TEMPLATED_PROPERTY_TYPE_INPUTS(ConvergenceProp, EnergyProp, FockProp, WfProp) {
-    using wf_type = simde::type::rscf_wf;
     auto rv     = pluginplay::declare_input()
                     .add_field<EnergyProp>("New Energy")
                     .template add_field<EnergyProp>("Old Energy")

--- a/include/scf/driver/convergence.hpp
+++ b/include/scf/driver/convergence.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "simde/simde.hpp"
+#include <pluginplay/pluginplay.hpp>
+
+namespace scf {
+
+/** @brief The property type for modules that return a molecule from a string
+ *         input.
+ *
+ * The usage of this property type can be pretty varied. Modules that satisfy
+ * this property type could potentially produce a molecule from a string with
+ * XYZ inputs, a SMILES string, or a molecule name outright.
+ *
+ */
+
+using simde::type::electronic_hamiltonian;
+using simde::type::hamiltonian;
+using simde::type::op_base_type;
+
+template<typename WfType>
+using egy_pt = simde::eval_braket<WfType, hamiltonian, WfType>;
+
+template<typename WfType>
+using elec_egy_pt = simde::eval_braket<WfType, electronic_hamiltonian, WfType>;
+
+template<typename WfType>
+using pt = simde::Optimize<egy_pt<WfType>, WfType>;
+
+template<typename WfType>
+using update_pt = simde::UpdateGuess<WfType>;
+
+using density_t = simde::type::decomposable_e_density;
+
+using fock_pt = simde::FockOperator<density_t>;
+
+using density_pt = simde::aos_rho_e_aos<simde::type::cmos>;
+
+using v_nn_pt = simde::charge_charge_interaction;
+
+using fock_matrix_pt = simde::aos_f_e_aos;
+using s_pt           = simde::aos_s_e_aos;
+ 
+DECLARE_PROPERTY_TYPE(ConvergenceProp);
+
+PROPERTY_TYPE_INPUTS(ConvergenceProp) {
+    using wf_type = simde::type::rscf_wf;
+    auto rv     = pluginplay::declare_input().add_field<elec_egy_pt<wf_type>>("Energy");
+    rv.at("String").set_description(
+      "The string identifying the desired molecule");
+    return rv;
+}
+
+PROPERTY_TYPE_RESULTS(ConvergenceProp) {
+    using mol_t = type::molecule;
+    auto rv     = pluginplay::declare_result().add_field<mol_t>("Molecule");
+    rv.at("Molecule")
+      .set_description("The molecule corresponding to the input string");
+    return rv;
+}
+
+} // namespace simde
+

--- a/src/scf/driver/convergence.cpp
+++ b/src/scf/driver/convergence.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "driver.hpp"
+
+namespace scf::driver {
+
+using simde::type::electronic_hamiltonian;
+using simde::type::hamiltonian;
+using simde::type::op_base_type;
+
+template<typename WfType>
+using egy_pt = simde::eval_braket<WfType, hamiltonian, WfType>;
+
+template<typename WfType>
+using elec_egy_pt = simde::eval_braket<WfType, electronic_hamiltonian, WfType>;
+
+template<typename WfType>
+using pt = simde::Optimize<egy_pt<WfType>, WfType>;
+
+template<typename WfType>
+using update_pt = simde::UpdateGuess<WfType>;
+
+using density_t = simde::type::decomposable_e_density;
+
+using fock_pt = simde::FockOperator<density_t>;
+
+using density_pt = simde::aos_rho_e_aos<simde::type::cmos>;
+
+using v_nn_pt = simde::charge_charge_interaction;
+
+using fock_matrix_pt = simde::aos_f_e_aos;
+using s_pt           = simde::aos_s_e_aos;
+
+struct GrabNuclear : chemist::qm_operator::OperatorVisitor {
+    using V_nn_type = simde::type::V_nn_type;
+
+    GrabNuclear() : chemist::qm_operator::OperatorVisitor(false) {}
+
+    void run(const V_nn_type& V_nn) { m_pv = &V_nn; }
+
+    const V_nn_type* m_pv;
+};
+
+MODULE_CTOR(SCFLoop) {
+    using wf_type = simde::type::rscf_wf;
+    description(desc);
+    satisfies_property_type<pt<wf_type>>();
+
+    const unsigned int max_itr = 20;
+    add_input<unsigned int>("max iterations").set_default(max_itr);
+    add_input<double>("energy tolerance").set_default(1.0E-6);
+    add_input<double>("density tolerance").set_default(1.0E-6);
+    add_input<double>("gradient tolerance").set_default(1.0E-6);
+
+    add_submodule<elec_egy_pt<wf_type>>("Electronic energy");
+    add_submodule<density_pt>("Density matrix");
+    add_submodule<update_pt<wf_type>>("Guess update");
+    add_submodule<fock_pt>("One-electron Fock operator");
+    add_submodule<fock_pt>("Fock operator");
+    add_submodule<fock_matrix_pt>("Fock matrix builder");
+    add_submodule<v_nn_pt>("Charge-charge");
+    add_submodule<s_pt>("Overlap matrix builder");
+}
+
+MODULE_RUN(SCFLoop) {
+    using wf_type               = simde::type::rscf_wf;
+    using density_op_type       = simde::type::rho_e<simde::type::cmos>;
+    const auto&& [braket, psi0] = pt<wf_type>::unwrap_inputs(inputs);
+        // Step 5: Converged?
+            // Change in the energy
+            simde::type::tensor de;
+            de("") = e_new("") - e_old("");
+
+            // Change in the density
+            simde::type::tensor dp;
+            dp("m,n")    = rho_new.value()("m,n") - rho_old.value()("m,n");
+            auto dp_norm = tensorwrapper::operations::infinity_norm(dp);
+
+            // Orbital gradient: FPS-SPF
+            // TODO: module satisfying BraKet(aos, Commutator(F,P), aos)
+            chemist::braket::BraKet F_mn(aos, f_new, aos);
+            const auto& F_matrix = F_mod.run_as<fock_matrix_pt>(F_mn);
+            simde::type::tensor FPS;
+            FPS("m,l") = F_matrix("m,n") * P_new("n,l");
+            FPS("m,l") = FPS("m,n") * S("n,l");
+
+            simde::type::tensor SPF;
+            SPF("m,l") = P_new("m,n") * F_matrix("n,l");
+            SPF("m,l") = S("m,n") * SPF("n,l");
+
+            simde::type::tensor grad;
+            simde::type::tensor grad_norm;
+            grad("m,n")   = FPS("m,n") - SPF("m,n");
+            grad_norm("") = grad("m,n") * grad("n,m");
+
+            Kernel k(get_runtime());
+
+            using tensorwrapper::utilities::floating_point_dispatch;
+            auto e_conv = floating_point_dispatch(k, de.buffer(), e_tol);
+            auto g_conv = floating_point_dispatch(k, grad_norm.buffer(), g_tol);
+            auto dp_conv = floating_point_dispatch(k, dp_norm.buffer(), dp_tol);
+
+            logger.log("  dE = " + de.to_string());
+            logger.log("  dP = " + dp_norm.to_string());
+            logger.log("  dG = " + grad_norm.to_string());
+
+            if(e_conv && g_conv && dp_conv) converged = true;
+        }
+
+        // Step 6: Not converged so reset
+        e_old   = e_new;
+        psi_old = psi_new;
+        rho_old = rho_new;
+        if(converged) break;
+        ++iter;
+    }

--- a/src/scf/driver/convergence.cpp
+++ b/src/scf/driver/convergence.cpp
@@ -45,17 +45,8 @@ using v_nn_pt = simde::charge_charge_interaction;
 using fock_matrix_pt = simde::aos_f_e_aos;
 using s_pt           = simde::aos_s_e_aos;
 
-struct GrabNuclear : chemist::qm_operator::OperatorVisitor {
-    using V_nn_type = simde::type::V_nn_type;
 
-    GrabNuclear() : chemist::qm_operator::OperatorVisitor(false) {}
-
-    void run(const V_nn_type& V_nn) { m_pv = &V_nn; }
-
-    const V_nn_type* m_pv;
-};
-
-MODULE_CTOR(SCFLoop) {
+MODULE_CTOR(ConvergenceMod) {
     using wf_type = simde::type::rscf_wf;
     description(desc);
     satisfies_property_type<pt<wf_type>>();
@@ -76,7 +67,7 @@ MODULE_CTOR(SCFLoop) {
     add_submodule<s_pt>("Overlap matrix builder");
 }
 
-MODULE_RUN(SCFLoop) {
+MODULE_RUN(ConvergenceMod) {
     using wf_type               = simde::type::rscf_wf;
     using density_op_type       = simde::type::rho_e<simde::type::cmos>;
     const auto&& [braket, psi0] = pt<wf_type>::unwrap_inputs(inputs);

--- a/src/scf/driver/convergence.cpp
+++ b/src/scf/driver/convergence.cpp
@@ -15,41 +15,13 @@
  */
 
 #include "driver.hpp"
+#include <driver/convergence.hpp>
 
 namespace scf::driver {
-
-using simde::type::electronic_hamiltonian;
-using simde::type::hamiltonian;
-using simde::type::op_base_type;
-
-template<typename WfType>
-using egy_pt = simde::eval_braket<WfType, hamiltonian, WfType>;
-
-template<typename WfType>
-using elec_egy_pt = simde::eval_braket<WfType, electronic_hamiltonian, WfType>;
-
-template<typename WfType>
-using pt = simde::Optimize<egy_pt<WfType>, WfType>;
-
-template<typename WfType>
-using update_pt = simde::UpdateGuess<WfType>;
-
-using density_t = simde::type::decomposable_e_density;
-
-using fock_pt = simde::FockOperator<density_t>;
-
-using density_pt = simde::aos_rho_e_aos<simde::type::cmos>;
-
-using v_nn_pt = simde::charge_charge_interaction;
-
-using fock_matrix_pt = simde::aos_f_e_aos;
-using s_pt           = simde::aos_s_e_aos;
-
-
-MODULE_CTOR(ConvergenceMod) {
+template<typename EnergyProp, typename FockProp, typename WfProp>
+TEMPLATED_MODULE_CTOR(ConvergenceMod, EnergyProp, FockProp, WfProp) {
     using wf_type = simde::type::rscf_wf;
-    description(desc);
-    satisfies_property_type<pt<wf_type>>();
+    satisfies_property_type<ConvergenceProp>();
 
     const unsigned int max_itr = 20;
     add_input<unsigned int>("max iterations").set_default(max_itr);

--- a/src/scf/driver/driver.hpp
+++ b/src/scf/driver/driver.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <simde/simde.hpp>
+#include <driver/convergence.hpp>
 
 namespace scf::driver {
 

--- a/src/scf/driver/driver.hpp
+++ b/src/scf/driver/driver.hpp
@@ -22,6 +22,8 @@ namespace scf::driver {
 
 DECLARE_MODULE(SCFDriver);
 DECLARE_MODULE(SCFLoop);
+
+template<typename KernelType>
 DECLARE_MODULE(ConvergenceMod);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {

--- a/src/scf/driver/driver.hpp
+++ b/src/scf/driver/driver.hpp
@@ -21,6 +21,7 @@ namespace scf::driver {
 
 DECLARE_MODULE(SCFDriver);
 DECLARE_MODULE(SCFLoop);
+DECLARE_MODULE(ConvergenceMod);
 
 inline void load_modules(pluginplay::ModuleManager& mm) {
     mm.add_module<SCFDriver>("SCF Driver");


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Removes the convergence test code in scf_loop.cpp to its own module.

**TODOs**
Implement convergence mod in scf_loop module
Better determine the scope of the property type and the module (Should it really take in 12 variables?)
Implement better template use so different types for the variables can be used
Implement the function into the defaults for the scf_loop module
Write tests
