### PR TITLE
Update Eigen dependency call to find installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ endforeach()
 
 cmaize_find_or_build_dependency(
     eigen
+    NAME Eigen3
     URL https://www.gitlab.com/libeigen/eigen
     VERSION 2e76277bd049f7bec36b0f908c69734a42c5234f
     BUILD_TARGET eigen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endforeach()
 cmaize_find_or_build_dependency(
     eigen
     URL https://www.gitlab.com/libeigen/eigen
-    VERSION 3.4.0
+    VERSION 2e76277bd049f7bec36b0f908c69734a42c5234f
     BUILD_TARGET eigen
     FIND_TARGET Eigen3::Eigen
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ cmaize_find_or_build_dependency(
     VERSION 2e76277bd049f7bec36b0f908c69734a42c5234f
     BUILD_TARGET eigen
     FIND_TARGET Eigen3::Eigen
+    CMAKE_ARGS EIGEN_BUILD_TESTING=OFF
 )
 
 cmaize_add_library(


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Similar update to NWChemEx/TensorWrapper#217.

**Description**
Eigen cannot be found without the proper name, `Eigen3`, while the current implementation searches for `eigen` right now. I have also disabled building the tests for Eigen. Additionally, I have updated the version it is looking for from 3.4.0 to the same commit as TensorWrapper.

**TODOs**
- [ ] Wait for tests to pass